### PR TITLE
ci: set workflow default shell to bash

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -18,6 +18,10 @@ on:
 
 permissions:
     contents: read
+
+defaults:
+  run:
+    shell: bash
   
 jobs:
     verify:


### PR DESCRIPTION
## Summary
- set `defaults.run.shell: bash` at workflow level for all run steps
- keep existing script logic unchanged while ensuring `pipefail`-compatible shell behavior in container jobs
- reduce per-step shell duplication and avoid shell drift across runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to standardize the default shell environment across all continuous integration job steps, improving consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->