### PR TITLE
fix: pin verified container digest

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -27,9 +27,18 @@ jobs:
   verify:
     name: Verify container
     runs-on: ubuntu-24.04-arm
+    outputs:
+      digest: ${{ steps.get-digest.outputs.digest }}
     steps:
         - name: Install Cosign
           uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+        - name: Get image digest
+          id: get-digest
+          run: |
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' docker://ghcr.io/xlionjuan/fedora-createrepo-image:latest)
+            echo "Resolved digest: ${DIGEST}"
+            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
         - name: Verify
           run: |
@@ -37,13 +46,13 @@ jobs:
             cosign verify --rekor-url=https://rekor.sigstore.dev \
             --certificate-identity-regexp "https://github.com/xlionjuan/.*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            ghcr.io/xlionjuan/fedora-createrepo-image:latest
+            ghcr.io/xlionjuan/fedora-createrepo-image@${{ steps.get-digest.outputs.digest }}
 
   prepare:
     name: Prepare
     runs-on: ubuntu-24.04-arm
     needs: verify
-    container: ghcr.io/xlionjuan/fedora-createrepo-image:latest
+    container: ghcr.io/xlionjuan/fedora-createrepo-image@${{ needs.verify.outputs.digest }}
     steps:
         - name: Checkout code
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,9 +154,9 @@ jobs:
   sign:
     name: Sign RPMs and repos
     runs-on: ubuntu-24.04-arm
-    needs: prepare
+    needs: [prepare, verify]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    container: ghcr.io/xlionjuan/fedora-createrepo-image:latest
+    container: ghcr.io/xlionjuan/fedora-createrepo-image@${{ needs.verify.outputs.digest }}
     steps:
         - name: Download unsigned artifacts
           uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary
- resolve ghcr.io/xlionjuan/fedora-createrepo-image:latest to an immutable digest in the verify job
- verify the resolved digest with cosign
- run later container jobs with the same verified digest to avoid a latest-tag TOCTOU window

## Notes
- pure container verification change only
- no SBOM verification or attestation changes
- mirrors the digest-pinning pattern from xlionjuan/ntpd-rs-repos#32

## Tests
- git diff --check
- python3 YAML parse for the workflow
- actionlint -shellcheck= for the workflow

Full actionlint still reports pre-existing shellcheck style/info warnings in existing run blocks.