### PR TITLE
chore(renovate): adopt shared presets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "enabledManagers": ["github-actions"],
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "digest", "pinDigest","major", "minor", "patch"],
-      "automerge": true,
-      "labels": ["dependencies"]
-    },
-    {
-      "matchUpdateTypes": ["pin", "digest", "pinDigest"],
-      "matchPackageNames": ["ghcr.io/xlionjuan/fedora-createrepo-image"],
-      "enabled": false
-    }
-  ]
+  "extends": ["local>xlionjuan/renovatebot-presets"]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>xlionjuan/renovatebot-presets"]
+  "extends": ["local>xlionjuan/renovatebot-presets"],
+  "packageRules": [
+    {
+      "description": "Keep the Fedora CI image on latest",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/fedora/fedora"],
+      "matchFileNames": [".gitlab-ci.yml"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- replace copied Renovate policy with `local>xlionjuan/renovatebot-presets`
- inherit the shared runtime-latest exception for `fedora-createrepo-image`
- keep `quay.io/fedora/fedora:latest` unmanaged in the root `.gitlab-ci.yml`
- remove the GitHub Actions manager allowlist and duplicated automerge rules

## Validation

- `renovate-config-validator --strict --no-global .github/renovate.json5`
- `git diff --check`
- pushed through the special `renovate/reconfigure` validation branch
